### PR TITLE
Changed save to happen at design time

### DIFF
--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -603,7 +603,7 @@ and internal SchemaCache =
             let ser = new System.Runtime.Serialization.Json.DataContractJsonSerializer(typeof<SchemaCache>)
             { (ser.ReadObject(ms) :?> SchemaCache) with IsOffline = true }
         static member LoadOrEmpty(filePath) =
-            if String.IsNullOrEmpty(filePath) then 
+            if String.IsNullOrEmpty(filePath) || (not(System.IO.File.Exists filePath)) then 
                 SchemaCache.Empty
             else
                 SchemaCache.Load(filePath)


### PR DESCRIPTION
Now you use it like this:
1. Choose whatever new file:

```fsharp
type sql = SqlDataProvider<..., ContextSchemaPath = @"c:\\test2.txt">
let ctx = sql.GetDataContext()
```
At this point the file doesn't exist so the SQLProvider uses online.
Write this in your code editor:

```fsharp
ctx.SaveContextSchema().
```

...and the intellisense gives the save result:
```fsharp
ctx.SaveContextSchema().``Saved c:\\test2.txt at 11:37:49``
```
Now the file is saved. Next time you load the project (on whatever way) the cached version will be used.
Until you delete the file or remove the static parameter.
